### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -11,6 +11,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/masquerade-app/proto/security/code-scanning/1](https://github.com/masquerade-app/proto/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs a linter, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the workflow level (before `jobs:`), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; just a single block of YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
